### PR TITLE
[#3 #4] 설질 투표 & 설질 정보 조회 API

### DIFF
--- a/src/main/kotlin/nexters/weski/snow_maker/SnowMakerController.kt
+++ b/src/main/kotlin/nexters/weski/snow_maker/SnowMakerController.kt
@@ -1,0 +1,20 @@
+package nexters.weski.snow_maker
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/snow-maker")
+
+class SnowMakerController(
+    private val snowMakerService: SnowMakerService
+) {
+    @GetMapping("/{resortId}")
+    fun getSnowMaker(@PathVariable resortId: Long): SnowMakerDto {
+        return snowMakerService.getSnowMaker(resortId)
+    }
+
+    @PostMapping("/{resortId}/vote")
+    fun voteSnowMaker(@PathVariable resortId: Long, @RequestParam isPositive: Boolean) {
+        snowMakerService.voteSnowMaker(resortId, isPositive)
+    }
+}

--- a/src/main/kotlin/nexters/weski/snow_maker/SnowMakerDto.kt
+++ b/src/main/kotlin/nexters/weski/snow_maker/SnowMakerDto.kt
@@ -1,0 +1,8 @@
+package nexters.weski.snow_maker
+
+data class SnowMakerDto(
+    val resortId: Long,
+    val totalVotes: Long,
+    val positiveVotes: Long,
+    val status: String,
+)

--- a/src/main/kotlin/nexters/weski/snow_maker/SnowMakerService.kt
+++ b/src/main/kotlin/nexters/weski/snow_maker/SnowMakerService.kt
@@ -1,0 +1,42 @@
+package nexters.weski.snow_maker
+
+import nexters.weski.ski_resort.SkiResortRepository
+import org.springframework.stereotype.Service
+
+@Service
+class SnowMakerService(
+    private val snowMakerVoteRepository: SnowMakerVoteRepository,
+    private val skiResortRepository: SkiResortRepository
+) {
+    fun getSnowMaker(resortId: Long): SnowMakerDto {
+        val totalVotes = snowMakerVoteRepository.countBySkiResortResortId(resortId)
+        val positiveVotes = snowMakerVoteRepository.countBySkiResortResortIdAndIsPositive(resortId, true)
+        val status = calculateStatus(totalVotes, positiveVotes)
+
+        return SnowMakerDto(
+            resortId = resortId,
+            totalVotes = totalVotes,
+            positiveVotes = positiveVotes,
+            status = status
+        )
+    }
+
+    fun voteSnowMaker(resortId: Long, isPositive: Boolean) {
+        val skiResort = skiResortRepository.findById(resortId).orElseThrow { Exception("Resort not found") }
+        val vote = SnowMakerVote(
+            isPositive = isPositive,
+            skiResort = skiResort
+        )
+        snowMakerVoteRepository.save(vote)
+    }
+
+    private fun calculateStatus(totalVotes: Long, positiveVotes: Long): String {
+        if (totalVotes == 0L) return "정보 없음"
+        val positiveRate = (positiveVotes.toDouble() / totalVotes.toDouble()) * 100
+        return when {
+            positiveRate >= 80 -> "좋음"
+            positiveRate >= 50 -> "나쁘지 않음"
+            else -> "좋지 않음"
+        }
+    }
+}

--- a/src/main/kotlin/nexters/weski/snow_maker/SnowMakerVote.kt
+++ b/src/main/kotlin/nexters/weski/snow_maker/SnowMakerVote.kt
@@ -1,0 +1,22 @@
+package nexters.weski.snow_maker
+
+
+import jakarta.persistence.*
+import nexters.weski.common.BaseEntity
+import nexters.weski.ski_resort.SkiResort
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "snow_quality_votes")
+data class SnowMakerVote(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val isPositive: Boolean,
+    val votedAt: LocalDateTime = LocalDateTime.now(),
+
+    @ManyToOne
+    @JoinColumn(name = "resort_id")
+    val skiResort: SkiResort
+) : BaseEntity()

--- a/src/main/kotlin/nexters/weski/snow_maker/SnowMakerVoteRepository.kt
+++ b/src/main/kotlin/nexters/weski/snow_maker/SnowMakerVoteRepository.kt
@@ -1,0 +1,8 @@
+package nexters.weski.snow_maker
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SnowMakerVoteRepository : JpaRepository<SnowMakerVote, Long> {
+    fun countBySkiResortResortId(resortId: Long): Long
+    fun countBySkiResortResortIdAndIsPositive(resortId: Long, isPositive: Boolean): Long
+}

--- a/src/test/kotlin/nexters/weski/snow_maker/SnowMakerControllerTest.kt
+++ b/src/test/kotlin/nexters/weski/snow_maker/SnowMakerControllerTest.kt
@@ -1,0 +1,57 @@
+package nexters.weski.snow_maker
+
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import nexters.weski.common.config.JpaConfig
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@WebMvcTest(SnowMakerController::class)
+@ComponentScan(
+    excludeFilters = [ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = [JpaConfig::class]
+    )]
+)
+class SnowMakerControllerTest @Autowired constructor(
+    private val mockMvc: MockMvc
+) {
+
+    @MockkBean
+    lateinit var snowMakerService: SnowMakerService
+
+    @Test
+    fun `GET api_snow-maker_resortId should return snow Maker data`() {
+        // Given
+        val resortId = 1L
+        val snowMakerDto = SnowMakerDto(resortId, 100, 80, "좋음")
+        every { snowMakerService.getSnowMaker(resortId) } returns snowMakerDto
+
+        // When & Then
+        mockMvc.perform(get("/api/snow-maker/$resortId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.totalVotes").value(100))
+            .andExpect(jsonPath("$.status").value("좋음"))
+    }
+
+    @Test
+    fun `POST api_snow-maker_resortId_vote should vote successfully`() {
+        // Given
+        val resortId = 1L
+        every { snowMakerService.voteSnowMaker(any(), any()) } just Runs
+
+        // When & Then
+        mockMvc.perform(post("/api/snow-maker/$resortId/vote")
+            .param("isPositive", "true"))
+            .andExpect(status().isOk)
+    }
+}

--- a/src/test/kotlin/nexters/weski/snow_maker/SnowMakerServiceTest.kt
+++ b/src/test/kotlin/nexters/weski/snow_maker/SnowMakerServiceTest.kt
@@ -1,0 +1,53 @@
+package nexters.weski.snow_maker
+
+
+import io.mockk.*
+import nexters.weski.ski_resort.ResortStatus
+import nexters.weski.ski_resort.SkiResort
+import nexters.weski.ski_resort.SkiResortRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class SnowMakerServiceTest {
+
+    private val snowMakerVoteRepository: SnowMakerVoteRepository = mockk(relaxed = true)
+    private val skiResortRepository: SkiResortRepository = mockk()
+    private val snowMakerService = SnowMakerService(snowMakerVoteRepository, skiResortRepository)
+
+    @Test
+    fun `getSnowMaker should return SnowMakerDto`() {
+        // Given
+        val resortId = 1L
+        every { snowMakerVoteRepository.countBySkiResortResortId(resortId) } returns 100
+        every { snowMakerVoteRepository.countBySkiResortResortIdAndIsPositive(resortId, true) } returns 80
+
+        // When
+        val result = snowMakerService.getSnowMaker(resortId)
+
+        // Then
+        assertEquals(100, result.totalVotes)
+        assertEquals(80, result.positiveVotes)
+        assertEquals("좋음", result.status)
+    }
+
+    @Test
+    fun `voteSnowMaker should save vote`() {
+        // Given
+        val resortId = 1L
+        val isPositive = true
+        val skiResort = SkiResort(resortId, "스키장 A", ResortStatus.운영중, null, null, 5, 10)
+        val snowMakerVote = SnowMakerVote(
+            isPositive = isPositive,
+            skiResort = skiResort
+        )
+        every { skiResortRepository.findById(resortId) } returns Optional.of(skiResort)
+        every { snowMakerVoteRepository.save(any()) } returns snowMakerVote
+
+        // When
+        snowMakerService.voteSnowMaker(resortId, isPositive)
+
+        // Then
+        verify { snowMakerVoteRepository.save(any()) }
+    }
+}


### PR DESCRIPTION

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/cb78e3d7-5cf8-46f2-87a2-edf736f437a1">


## 설질 정보 조회 API

현재 스키장의 설질에 대한 투표 결과를 제공합니다.

### Endpoint

- `GET /api/snow-making/{resortId}`

### 요청 파라미터

- `resortId` (Path Parameter): 스키장 ID

### 응답

```json
{
  "totalVotes": 100,
  "positiveVotes": 80,
  "status": "상태가 좋아요" // "상태가 좋아요", "나쁘지 않아요", "좋지 않아요"
}
```

### 상태 결정 로직

- 긍정 투표 비율이 80% 이상: `좋음`
- 긍정 투표 비율이 50% 이상 80% 미만: `나쁘지 않음`
- 긍정 투표 비율이 50% 미만: `좋지 않음`

## 설질 투표 API

설질에 대한 사용자의 투표를 등록합니다.

### Endpoint

- `POST /api/snow-making/{resortId}/vote`

### 요청 파라미터

- `resortId` (Path Parameter): 스키장 ID

### 요청 바디

```json
{
  "isPositive": true // 설질이 괜찮을 것 같다면 true, 아니면 false
}

```

### 응답

```json
{
  "message": "투표가 성공적으로 반영되었습니다."
}

```