### PR TITLE
[#18] 시간대별 날씨 업데이트 batch

### DIFF
--- a/src/main/kotlin/nexters/weski/batch/WeatherScheduler.kt
+++ b/src/main/kotlin/nexters/weski/batch/WeatherScheduler.kt
@@ -14,7 +14,11 @@ class WeatherScheduler(
 
     @Scheduled(cron = "0 30 3 * * *")
     fun scheduledDailyWeatherUpdate() {
-        externalWeatherService.updateDDayValues()
         externalWeatherService.updateDailyWeather()
+    }
+
+    @Scheduled(cron = "00 22 4 * * *")
+    fun scheduledHourlyAndDailyUpdate() {
+        externalWeatherService.updateHourlyAndDailyWeather()
     }
 }

--- a/src/main/kotlin/nexters/weski/batch/WeatherScheduler.kt
+++ b/src/main/kotlin/nexters/weski/batch/WeatherScheduler.kt
@@ -17,7 +17,7 @@ class WeatherScheduler(
         externalWeatherService.updateDailyWeather()
     }
 
-    @Scheduled(cron = "00 22 4 * * *")
+    @Scheduled(cron = "0 10 5 * * *")
     fun scheduledHourlyAndDailyUpdate() {
         externalWeatherService.updateHourlyAndDailyWeather()
     }

--- a/src/main/kotlin/nexters/weski/weather/DailyWeather.kt
+++ b/src/main/kotlin/nexters/weski/weather/DailyWeather.kt
@@ -12,14 +12,14 @@ data class DailyWeather(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    val forecastDate: LocalDate,
-    val dayOfWeek: String,
+    var forecastDate: LocalDate,
+    var dayOfWeek: String,
     val dDay: Int,
-    val precipitationChance: Int,
-    val maxTemp: Int,
-    val minTemp: Int,
+    var precipitationChance: Int,
+    var maxTemp: Int,
+    var minTemp: Int,
     @Column(name = "`condition`")
-    val condition: String,
+    var condition: String,
 
     @ManyToOne
     @JoinColumn(name = "resort_id")

--- a/src/main/kotlin/nexters/weski/weather/DailyWeatherRepository.kt
+++ b/src/main/kotlin/nexters/weski/weather/DailyWeatherRepository.kt
@@ -1,15 +1,10 @@
 package nexters.weski.weather
 
+import nexters.weski.ski_resort.SkiResort
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
 
 interface DailyWeatherRepository : JpaRepository<DailyWeather, Long> {
     fun findAllBySkiResortResortId(resortId: Long): List<DailyWeather>
     fun deleteByDDayGreaterThanEqual(dDay: Int)
-    fun deleteByDDay(dDay: Int)
-
-    @Modifying
-    @Query("UPDATE DailyWeather dw SET dw.dDay = dw.dDay - 1 WHERE dw.dDay > 0")
-    fun decrementDDayValues()
+    fun findBySkiResortAndDDay(skiResort: SkiResort, dDay: Int): DailyWeather?
 }

--- a/src/main/kotlin/nexters/weski/weather/HourlyWeather.kt
+++ b/src/main/kotlin/nexters/weski/weather/HourlyWeather.kt
@@ -3,7 +3,6 @@ package nexters.weski.weather
 import jakarta.persistence.*
 import nexters.weski.common.BaseEntity
 import nexters.weski.ski_resort.SkiResort
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "hourly_weather")
@@ -12,9 +11,11 @@ data class HourlyWeather(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    val forecastTime: LocalDateTime,
+    val forecastTime: String,
+    val priority: Int,
     val temperature: Int,
     val precipitationChance: Int,
+    @Column(name = "`condition`")
     val condition: String,
 
     @ManyToOne

--- a/src/main/kotlin/nexters/weski/weather/HourlyWeatherRepository.kt
+++ b/src/main/kotlin/nexters/weski/weather/HourlyWeatherRepository.kt
@@ -1,12 +1,8 @@
 package nexters.weski.weather
 
+import nexters.weski.ski_resort.SkiResort
 import org.springframework.data.jpa.repository.JpaRepository
-import java.time.LocalDateTime
 
 interface HourlyWeatherRepository : JpaRepository<HourlyWeather, Long> {
-    fun findAllBySkiResortResortIdAndForecastTimeBetween(
-        resortId: Long,
-        startTime: LocalDateTime,
-        endTime: LocalDateTime
-    ): List<HourlyWeather>
+    fun deleteBySkiResort(skiResort: SkiResort)
 }

--- a/src/main/kotlin/nexters/weski/weather/WeatherDto.kt
+++ b/src/main/kotlin/nexters/weski/weather/WeatherDto.kt
@@ -55,7 +55,7 @@ data class HourlyWeatherDto(
     companion object {
         fun fromEntity(entity: HourlyWeather): HourlyWeatherDto {
             return HourlyWeatherDto(
-                time = entity.forecastTime.toLocalTimeString(),
+                time = entity.forecastTime,
                 temperature = entity.temperature,
                 precipitationChance = entity.precipitationChance.toPercentString(),
                 condition = entity.condition

--- a/src/main/kotlin/nexters/weski/weather/WeatherService.kt
+++ b/src/main/kotlin/nexters/weski/weather/WeatherService.kt
@@ -1,8 +1,6 @@
 package nexters.weski.weather
 
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
-import java.time.LocalTime
 
 @Service
 class WeatherService(
@@ -12,12 +10,7 @@ class WeatherService(
 ) {
     fun getWeatherByResortId(resortId: Long): WeatherDto? {
         val currentWeather = currentWeatherRepository.findBySkiResortResortId(resortId) ?: return null
-        // 오늘, 내일 날짜의 날씨 정보만 가져옴
-        val startTime = LocalDateTime.now().with(LocalTime.MIN)
-        val endTime = startTime.plusDays(2).with(LocalTime.MAX)
-        val hourlyWeather = hourlyWeatherRepository.findAllBySkiResortResortIdAndForecastTimeBetween(
-            resortId, startTime, endTime
-        )
+        val hourlyWeather = hourlyWeatherRepository.findAll()
         val dailyWeather = dailyWeatherRepository.findAllBySkiResortResortId(resortId)
 
         return WeatherDto.fromEntities(currentWeather, hourlyWeather, dailyWeather)

--- a/src/test/kotlin/nexters/weski/weather/WeatherServiceTest.kt
+++ b/src/test/kotlin/nexters/weski/weather/WeatherServiceTest.kt
@@ -20,18 +20,16 @@ class WeatherServiceTest {
     fun `getWeatherByResortId should return WeatherDto`() {
         // Given
         val resortId = 1L
-        val skiResort = SkiResort(resortId, "스키장 A", ResortStatus.운영중, null, null, 5, 10)
+        val skiResort = SkiResort(
+            resortId, "스키장 A", ResortStatus.운영중, null, null, 5, 10,
+            "09:00 ~ 17:00", "18:00 ~ 22:00", "22:00 ~ 24:00", "06:00 ~ 09:00", "00:00 ~ 02:00",
+            "눈이 내리고 있습니다.", "37.123456", "127.123456", "123456", "123456"
+        )
         val currentWeather = CurrentWeather(
             resortId, -5, -2, -8, -10, "눈이 내리고 있습니다.", "눈", skiResort
         )
         every { currentWeatherRepository.findBySkiResortResortId(resortId) } returns currentWeather
-        every {
-            hourlyWeatherRepository.findAllBySkiResortResortIdAndForecastTimeBetween(
-                resortId,
-                any(),
-                any()
-            )
-        } returns listOf()
+        every { hourlyWeatherRepository.findAll() } returns listOf()
         every { dailyWeatherRepository.findAllBySkiResortResortId(resortId) } returns listOf()
 
         // When


### PR DESCRIPTION
# Feature

1. **시간대별 날씨 데이터 업데이트**: 각 스키 리조트에 대해 오늘 오전 8시부터 다음날 오전 2시까지 2시간 단위의 날씨 데이터를 `hourly_weather` 테이블에 업데이트
2. **주간 날씨 데이터 업데이트**: `daily_weather` 테이블에서 `d_day`가 0(오늘)과 1(내일)인 데이터 업데이트

---

# Flow

1. **API 호출 및 데이터 파싱**:
    - 기상청 단기예보조회 API(`getVilageFcst`)를 호출하여 필요한 데이터 조회
    - 응답 데이터를 파싱하여 필요한 항목(`TMP`, `POP`, `SKY`, `PTY`)을 추출
2. **시간대별 날씨 데이터 생성 및 저장**:
    - 지정된 시간대(08:00부터 02:00까지 2시간 간격)에 해당하는 데이터를 추출
    - 각 시간대별로 우선순위(`priority`)를 설정
    - `hourly_weather` 테이블에 데이터를 저장
3. **주간 날씨 데이터 업데이트**:
    - 오늘과 내일(`d_day`가 0과 1)에 대한 데이터를 처리
    - 해당 일자의 모든 강수확률(`POP`) 중 최대값을 `precipitation_chance`로 설정
    - 하늘상태(`SKY`)와 강수형태(`PTY`)를 기반으로 가장 나쁜 상태를 `condition`으로 설정
    - `daily_weather` 테이블에 데이터 갱신
