### PR TITLE
[#23] 오늘 날씨 최고/최저 기온 업데이트 오류 수정

### DIFF
--- a/src/main/kotlin/nexters/weski/weather/DailyWeatherRepository.kt
+++ b/src/main/kotlin/nexters/weski/weather/DailyWeatherRepository.kt
@@ -2,9 +2,11 @@ package nexters.weski.weather
 
 import nexters.weski.ski_resort.SkiResort
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
 
 interface DailyWeatherRepository : JpaRepository<DailyWeather, Long> {
     fun findAllBySkiResortResortId(resortId: Long): List<DailyWeather>
     fun deleteByDDayGreaterThanEqual(dDay: Int)
     fun findBySkiResortAndDDay(skiResort: SkiResort, dDay: Int): DailyWeather?
+    fun findBySkiResortAndForecastDate(skiResort: SkiResort, forecastDate: LocalDate): List<DailyWeather>
 }


### PR DESCRIPTION
# 원인

- 기상청 단기 예보 API 중 `초단기실황` API에는 최고/최저 기온을 지원하지 않음

# 해결 방법

- 단기예보 API에서 추출한 최고/최저 기온을 `current_weather` table에 업데이트
- 단기예보보다 초단기실황 API 데이터가 더 정확하기 때문에 초단기실황 기온이 최고/최저를 갱신하면 업데이트하도록 수정