### PR TITLE
[#25] 스키장 전체 조회 시 개장일 빠른 순서로 정렬 기준 변경

### DIFF
--- a/src/main/kotlin/nexters/weski/ski_resort/SkiResortRepository.kt
+++ b/src/main/kotlin/nexters/weski/ski_resort/SkiResortRepository.kt
@@ -2,4 +2,6 @@ package nexters.weski.ski_resort
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface SkiResortRepository : JpaRepository<SkiResort, Long>
+interface SkiResortRepository : JpaRepository<SkiResort, Long> {
+    fun findAllByOrderByOpeningDateAsc(): List<SkiResort>
+}

--- a/src/main/kotlin/nexters/weski/ski_resort/SkiResortService.kt
+++ b/src/main/kotlin/nexters/weski/ski_resort/SkiResortService.kt
@@ -11,7 +11,7 @@ class SkiResortService(
     private val dailyWeatherRepository: DailyWeatherRepository
 ) {
     fun getAllSkiResortsAndWeather(): List<SkiResortResponseDto> {
-        val skiResorts = skiResortRepository.findAll()
+        val skiResorts = skiResortRepository.findAllByOrderByOpeningDateAsc()
         return skiResorts.map { skiResort ->
             val currentWeather = currentWeatherRepository.findBySkiResortResortId(skiResort.resortId)
             val weeklyWeather = dailyWeatherRepository.findAllBySkiResortResortId(skiResort.resortId)


### PR DESCRIPTION
# 개요

App UX 개선을 위해 스키장 목록 조회 시 개장일이 빠른 순서로 정렬 기준을 변경합니다.

# 변경 내용

## `AS-IS` 

```json
[
  {
    "resortId": 1,
    "name": "지산 리조트",
    "status": "예정",
    "openSlopes": 0,
    },
// 2, 3, 4, ... 생략
  {
    "resortId": 11,
    "name": "오투리조트",
    "status": "예정",
    "openSlopes": 0,
  }
]
```

## `TO-BE`

```json
[
  {
    "resortId": 6,
    "name": "휘닉스파크",
    "status": "예정",
    "openingDate": "2024-11-22",
    "closingDate": "미정",
    "openSlopes": 0,
  },
// openingDate 빠른 순서로 정렬
  {
    "resortId": 8,
    "name": "용평스키장 모나",
    "status": "예정",
    "openingDate": "2024-11-22",
    "closingDate": "미정",
    "openSlopes": 0,
  }
]
```
