### PR TITLE
[#22] 스키장 슬로프, 웹캠 정보 조회 API 식별자 추가

### DIFF
--- a/src/main/kotlin/nexters/weski/slope/SlopeDto.kt
+++ b/src/main/kotlin/nexters/weski/slope/SlopeDto.kt
@@ -1,24 +1,28 @@
 package nexters.weski.slope
 
 data class SlopeDto(
+    val slopeId: Long,
     val name: String,
     val difficulty: String,
     val isDayOperating: Boolean,
     val isNightOperating: Boolean,
     val isLateNightOperating: Boolean,
     val isDawnOperating: Boolean,
-    val isMidnightOperating: Boolean
+    val isMidnightOperating: Boolean,
+    val webcamNo: Int?
 ) {
     companion object {
         fun fromEntity(entity: Slope): SlopeDto {
             return SlopeDto(
+                slopeId = entity.id,
                 name = entity.name,
                 difficulty = entity.difficulty.name,
                 isDayOperating = entity.isDayOperating,
                 isNightOperating = entity.isNightOperating,
                 isLateNightOperating = entity.isLateNightOperating,
                 isDawnOperating = entity.isDawnOperating,
-                isMidnightOperating = entity.isMidnightOperating
+                isMidnightOperating = entity.isMidnightOperating,
+                webcamNo = entity.webcamNumber
             )
         }
     }


### PR DESCRIPTION
# Info

웹 클라이언트 측 슬로프/웹캠 구분할 수 있는 식별자 필요 대응

# Detail

- 이미 데이터는 구축해뒀기 때문에 Response DTO만 수정

<img width="738" alt="image" src="https://github.com/user-attachments/assets/f91c2dd2-7b4b-4389-a1be-1edd8198d388">


#22