### PR TITLE
[#30] (CS) 즐겨찾기 기능 대응 : 특정 스키장 정보 조회 API 개발

### DIFF
--- a/http/API-TEST.http
+++ b/http/API-TEST.http
@@ -4,6 +4,9 @@
 ### 스키장 정보 조회 API
 GET http://localhost:8080/api/ski-resorts
 
+### 스키장 정보 조회 API
+GET http://localhost:8080/api/ski-resort/{{resortId}}
+
 ### 날씨 정보 조회 API
 GET http://localhost:8080/api/weather/{{resortId}}
 

--- a/src/main/kotlin/nexters/weski/ski_resort/SkiResortController.kt
+++ b/src/main/kotlin/nexters/weski/ski_resort/SkiResortController.kt
@@ -1,8 +1,10 @@
 package nexters.weski.ski_resort
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "전체 스키장 정보 API", description = "전체 스키장 날씨 및 슬로프 정보 관련")
@@ -14,5 +16,14 @@ class SkiResortController(
     @GetMapping("/api/ski-resorts")
     fun getAllSkiResorts(): List<SkiResortResponseDto> {
         return skiResortService.getAllSkiResortsAndWeather()
+    }
+
+    @Operation(summary = "날씨와 슬로프 정보를 포함한 특정 스키장 데이터를 조회하는 API")
+    @GetMapping("/api/ski-resort/{resortId}")
+    fun getSkiResort(
+        @Parameter(description = "스키장 ID", example = "1")
+        @PathVariable resortId: Long
+    ): SkiResortResponseDto {
+        return skiResortService.getSkiResortAndWeather(resortId)
     }
 }

--- a/src/main/kotlin/nexters/weski/ski_resort/SkiResortService.kt
+++ b/src/main/kotlin/nexters/weski/ski_resort/SkiResortService.kt
@@ -22,6 +22,16 @@ class SkiResortService(
         }
     }
 
+    fun getSkiResortAndWeather(resortId: Long): SkiResortResponseDto {
+        val skiResort = skiResortRepository.findById(resortId)
+            .orElseThrow { IllegalArgumentException("해당 ID의 스키장이 존재하지 않습니다.") }
+
+        val currentWeather = currentWeatherRepository.findBySkiResortResortId(skiResort.resortId)
+        val weeklyWeather = dailyWeatherRepository.findAllBySkiResortResortId(skiResort.resortId)
+
+        return SkiResortResponseDto.fromEntity(skiResort, currentWeather, weeklyWeather)
+    }
+
     fun updateResortDate(resortId: Long, dateType: DateType, date: LocalDate) {
         val skiResort = skiResortRepository.findById(resortId)
             .orElseThrow { IllegalArgumentException("해당 ID의 스키장이 존재하지 않습니다.") }


### PR DESCRIPTION
# 개요

즐겨찾기 기능에 대응하기 위해 `특정 스키장 정보 조회 API`를 개발합니다.(단기 대응)

## 참고

- 로그인이나 디바이스 정보를 구분할 수 없기 때문에 App에서 즐겨찾기 항목 저장
- 특정 스키장 정보 조회 API를 호출해서 App측에서 구성

# 변경 내용

## `Add` 

```bash
### 스키장 정보 조회 API
GET http://localhost:8080/api/ski-resort/{{resortId}}
```

<img width="829" alt="image" src="https://github.com/user-attachments/assets/d6b633a2-a763-493e-97e3-241b301455e2">



#30 
