### PR TITLE
[#35] 기상청 중기예보 API 응답 변경 대응

### DIFF
--- a/src/main/kotlin/nexters/weski/batch/ExternalWeatherService.kt
+++ b/src/main/kotlin/nexters/weski/batch/ExternalWeatherService.kt
@@ -180,7 +180,7 @@ class ExternalWeatherService(
 
         val tmFc = baseDate.format(DateTimeFormatter.ofPattern("yyyyMMdd")) + baseTime
         // 기존 데이터 삭제
-        dailyWeatherRepository.deleteByDDayGreaterThanEqual(2)
+        dailyWeatherRepository.deleteByDDayGreaterThanEqual(4)
         skiResortRepository.findAll().forEach { resort ->
             val detailedAreaCode = resort.detailedAreaCode
             val broadAreaCode = resort.broadAreaCode
@@ -252,7 +252,7 @@ class ExternalWeatherService(
             return weatherList
         }
 
-        for (i in 3..10) {
+        for (i in 5..10) {
             val forecastDate = now.plusDays(i.toLong() - 1)
             val dayOfWeek = forecastDate.dayOfWeek.name // 영어 요일명
 
@@ -280,7 +280,7 @@ class ExternalWeatherService(
 
     private fun getPrecipitationChance(midLandData: JsonNode, day: Int): Int {
         return when (day) {
-            in 3..7 -> {
+            in 5..7 -> {
                 val amChance = midLandData.get("rnSt${day}Am")?.asInt() ?: 0
                 val pmChance = midLandData.get("rnSt${day}Pm")?.asInt() ?: 0
                 maxOf(amChance, pmChance)
@@ -296,7 +296,7 @@ class ExternalWeatherService(
 
     private fun getCondition(midLandData: JsonNode, day: Int): String {
         return when (day) {
-            in 3..7 -> {
+            in 5..7 -> {
                 val amCondition = midLandData.get("wf${day}Am")?.asText() ?: ""
                 val pmCondition = midLandData.get("wf${day}Pm")?.asText() ?: ""
                 selectWorseCondition(amCondition, pmCondition)


### PR DESCRIPTION
# 기상청 중기예보 API response 변경

- AS-WAS : 3~10일 날씨 데이터 제공
- TO-BE: 5~10일 날씨 데이터만 제공

<img width="2145" alt="image" src="https://github.com/user-attachments/assets/0ce73f6a-6117-46de-b788-d9b4bcfe8ce4" />

## 현상

3~4일 데이터 비노출

<img width="400" alt="image" src="https://github.com/user-attachments/assets/90ceb7fe-935c-464a-9738-509edec4c62e" />