### PR TITLE
[#39] 스키장 날씨 조회 API 정렬 기준 추가

### DIFF
--- a/src/main/kotlin/nexters/weski/ski_resort/SkiResortService.kt
+++ b/src/main/kotlin/nexters/weski/ski_resort/SkiResortService.kt
@@ -18,7 +18,11 @@ class SkiResortService(
         val skiResorts = skiResortRepository.findAllByOrderByOpeningDateAsc()
         return skiResorts.map { skiResort ->
             val currentWeather = currentWeatherRepository.findBySkiResortResortId(skiResort.resortId)
-            val weeklyWeather = dailyWeatherRepository.findAllBySkiResortResortId(skiResort.resortId)
+            val weeklyWeather = dailyWeatherRepository.findBySkiResortAndForecastDateBetweenOrderByForecastDate(
+                skiResort = skiResort,
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(7)
+            )
 
             SkiResortResponseDto.fromEntity(skiResort, currentWeather, weeklyWeather)
         }
@@ -29,7 +33,11 @@ class SkiResortService(
             .orElseThrow { IllegalArgumentException("해당 ID의 스키장이 존재하지 않습니다.") }
 
         val currentWeather = currentWeatherRepository.findBySkiResortResortId(skiResort.resortId)
-        val weeklyWeather = dailyWeatherRepository.findAllBySkiResortResortId(skiResort.resortId)
+        val weeklyWeather = dailyWeatherRepository.findBySkiResortAndForecastDateBetweenOrderByForecastDate(
+            skiResort = skiResort,
+            startDate = LocalDate.now(),
+            endDate = LocalDate.now().plusDays(7)
+        )
 
         return SkiResortResponseDto.fromEntity(skiResort, currentWeather, weeklyWeather)
     }

--- a/src/main/kotlin/nexters/weski/weather/DailyWeatherRepository.kt
+++ b/src/main/kotlin/nexters/weski/weather/DailyWeatherRepository.kt
@@ -5,9 +5,15 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDate
 
 interface DailyWeatherRepository : JpaRepository<DailyWeather, Long> {
-    fun findAllBySkiResortResortId(resortId: Long): List<DailyWeather>
+    fun findBySkiResortAndForecastDateBetweenOrderByForecastDate(
+        skiResort: SkiResort,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<DailyWeather>
+
     fun findBySkiResortAndForecastDate(skiResort: SkiResort, forecastDate: LocalDate): DailyWeather?
-    fun findAllBySkiResortResortIdAndForecastDateBetween(
+
+    fun findAllBySkiResortResortIdAndForecastDateBetweenOrderByForecastDate(
         resortId: Long,
         startDate: LocalDate,
         endDate: LocalDate

--- a/src/main/kotlin/nexters/weski/weather/WeatherService.kt
+++ b/src/main/kotlin/nexters/weski/weather/WeatherService.kt
@@ -16,7 +16,7 @@ class WeatherService(
         val today = LocalDate.now()
         val after7Days = today.plusDays(7)
 
-        val dailyWeather = dailyWeatherRepository.findAllBySkiResortResortIdAndForecastDateBetween(
+        val dailyWeather = dailyWeatherRepository.findAllBySkiResortResortIdAndForecastDateBetweenOrderByForecastDate(
             resortId = resortId,
             startDate = today,
             endDate = after7Days


### PR DESCRIPTION
# 문제

스키장 날씨 조회 API 응답 날씨 순서가 일부 정렬되지 않고 조회 됨

# 원인

- 기상청 날씨 response 변경 대응으로 내부 DB 날짜별 날씨 저장 정책이 변경 됨
- 기존에는 날씨 업데이트 시 삭제했지만, 현재는 upsert되고, 순서가 일부 보장되지 않음

<img width="450" alt="image" src="https://github.com/user-attachments/assets/2b7505bd-4ae6-46e0-aaba-4da598b22bfd" />

<img width="450" alt="image" src="https://github.com/user-attachments/assets/8ffd28ac-68bb-4436-8af4-7e2696b56205" />

# 해결

<img width="450" alt="image" src="https://github.com/user-attachments/assets/57c19891-0661-4177-b9e8-025d5103f140" />


# Issue

#39 